### PR TITLE
[Haipeng] fluentd is facing OOM on staging env

### DIFF
--- a/modules/fluentd/templates/fluentd.nomad
+++ b/modules/fluentd/templates/fluentd.nomad
@@ -103,7 +103,7 @@ EOH
 
       resources {
         cpu    = 3000
-        memory = 512
+        memory = 1024
 
         network {
           mbits = 100


### PR DESCRIPTION
just change the memory limit from 512 to 1024 due to OOM.