### PR TITLE
Update ignore change to all

### DIFF
--- a/modules/vault-pki/main.tf
+++ b/modules/vault-pki/main.tf
@@ -49,7 +49,7 @@ resource "vault_generic_secret" "pki_ca" {
 
   lifecycle {
     # This is a hack. Reconfiguring this will overwrite the CA
-    ignore_changes = ["*"]
+    ignore_changes = all
   }
 }
 


### PR DESCRIPTION


  on .terraform/modules/pki/modules/vault-pki/main.tf line 52, in resource "vault_generic_secret" "pki_ca":
  52:     ignore_changes = ["*"]

The ["*"] form of ignore_changes wildcard is deprecated. Use "ignore_changes =
all" to ignore changes to all attributes.
